### PR TITLE
Remove react-native peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
   "bugs": {
     "url": "https://github.com/react-native-fellowship/react-native-blur/issues"
   },
-  "homepage": "https://github.com/react-native-fellowship/react-native-blur",
-  "peerDependencies": {
-    "react-native": ">=0.11"
-  }
+  "homepage": "https://github.com/react-native-fellowship/react-native-blur"
 }


### PR DESCRIPTION
Usually causes more problems than it solves and others have been removing it, too:

- https://github.com/oblador/react-native-vector-icons/issues/76
- https://github.com/Yomguithereal/baobab-react/issues/59
- https://github.com/rebeccahughes/react-native-device-info/issues/16