### PR TITLE
bumped react-native version to ^0.21.0 to fix issue with npm v3 compatibility

### DIFF
--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -6,7 +6,7 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react-native": "^0.11.4",
+    "react-native": "^0.21.0",
     "react-native-blur": "^0.7.0"
   }
 }


### PR DESCRIPTION
This change ultimately resolves the issue where a user with NPM v3 installed receives the error: 'Could not find dependencies.’ when running `npm start`.