### PR TITLE
Update react-native-blur.podspec

### DIFF
--- a/react-native-blur.podspec
+++ b/react-native-blur.podspec
@@ -1,7 +1,13 @@
 Pod::Spec.new do |s|
-  s.name         = "react-native-blur"
-  s.version      = "0.7.9"
+  s.name          = "react-native-blur"
+  s.version       = "0.7.10"
   s.source_files  = "ios/*.{h,m}"
+  s.platform      = :ios, "8.0"
+  s.authors       = { "Alexey Kureev" => "kureev-mail@ya.ru" }
+  s.license       = "MIT"
+  s.summary       = "Component implementation for UIVisualEffectView's blur and vibrancy effect."
+  s.homepage      = "https://github.com/react-native-fellowship/react-native-blur"
+  s.source        = { :git => "https://github.com/react-native-fellowship/react-native-blur.git" }
+
   s.dependency 'React'
-  s.platform = :ios, "8.0"
 end


### PR DESCRIPTION
Latest version of cocoa pods rejects this pod spec.

Resolved error due to missing authors
Resolved error due to missing homepage
Resolved error due to missing source
Resolved error due to missing summary
Resolved warning due to missing license