### PR TITLE
Updated example to use ES6 features

### DIFF
--- a/examples/Basic/index.ios.js
+++ b/examples/Basic/index.ios.js
@@ -1,17 +1,11 @@
-var React = require('react');
-var {
-  Component,
-  PropTypes
-} = React;
-
-var ReactNative = require('react-native');
-var {
+import React, {Component} from 'react';
+import {
   AppRegistry,
   StyleSheet,
   Text,
-  View,
   Image,
-} = ReactNative;
+} from 'react-native';
+import {BlurView, VibrancyView} from 'react-native-blur';
 
 const styles = StyleSheet.create({
   container: {
@@ -27,15 +21,12 @@ const styles = StyleSheet.create({
   },
 });
 
-var BlurView = require('react-native-blur').BlurView;
-var VibrancyView = require('react-native-blur').VibrancyView;
-
-var background = 'http://iphonewallpapers-hd.com/thumbs/firework_iphone_wallpaper_5-t2.jpg';
+const background = 'http://iphonewallpapers-hd.com/thumbs/firework_iphone_wallpaper_5-t2.jpg';
 
 class Basic extends Component {
   render() {
     return (
-      <Image source={{uri: background, }} style={styles.container}>
+      <Image source={{uri: background}} style={styles.container}>
         <BlurView blurType="light" style={styles.container}>
          <Text style={styles.welcome}>Blur component</Text>
         </BlurView>


### PR DESCRIPTION
Used imports instead of require.
Simplified imports and removed unused component View.
Background is now a const instead of var. <- ES6 prefers this
Removed dangling comma after background `source={{uri: background, }}`

Generally example is more succinct and easier to understand for users only exposed to the new tools of ES6.

Below is an image of the example, just to prove it is still functioning!

![simulator screen shot 1 jul 2016 09 14 53](https://cloud.githubusercontent.com/assets/10632072/16515842/5a347ebe-3f6c-11e6-99a9-3fd343504d27.png)
